### PR TITLE
[release] 0.1.1 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.1.1](https://github.com/eonu/daze/releases/tag/v0.1.1)
+
+#### Major changes
+
+- Add [RTD documentation link](https://daze.readthedocs.io/en/latest) and installation instructions to `README.md`. ([#7](https://github.com/eonu/daze/pull/7))
+
+#### Minor changes
+
+- Change _'prediction and true measure'_ to _'row and column measure'_ in the docstring for the `Count` measure. ([#8](https://github.com/eonu/daze/pull/8))
+
 ## [0.1.0](https://github.com/eonu/daze/releases/tag/v0.1.0)
 
 #### Major changes

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ to the original Scikit-Learn function.
   _TPR, FPR, TNR, FNR, Precision, Recall, F1_.
 - Supports both classifiers and pre-computed confusion matrices.
 
+## Installation
+
+```console
+pip install daze
+```
+
 ## Documentation
 
 The package API remains largely the same as that of `sklearn.metrics.plot_confusion_matrix` with a few additions and changes to the function arguments:
@@ -72,9 +78,7 @@ The package API remains largely the same as that of `sklearn.metrics.plot_confus
 </p>
 </details>
 
-<!-- Additions to sklearn API - also mention normalize -->
-<!-- Link to docs -->
-<!-- Table of measurese -->
+Documentation for the package is available on [Read The Docs](https://daze.readthedocs.io/en/latest).
 
 ## Examples
 

--- a/lib/daze/__init__.py
+++ b/lib/daze/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 from .measures import *
 from .daze import *

--- a/lib/daze/measures.py
+++ b/lib/daze/measures.py
@@ -25,7 +25,7 @@ class Accuracy(_SummaryMeasure):
         return TP(self.cm)().sum() / self.cm.sum()
 
 class Count(_ColumnMeasure, _RowMeasure):
-    """A prediction and true measure that computes the counts of rows/columns."""
+    """A row and column measure that computes the counts of rows/columns."""
     name, label = 'c', '#'
 
     def __call__(self, axis):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'matplotlib'
 ]
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()


### PR DESCRIPTION
# Major changes

- Add [RTD documentation link](https://daze.readthedocs.io/en/latest) and installation instructions to `README.md`. ([#7](https://github.com/eonu/daze/pull/7))

# Minor changes

- Change _'prediction and true measure'_ to _'row and column measure'_ in the docstring for the `Count` measure. ([#8](https://github.com/eonu/daze/pull/8))